### PR TITLE
検索結果からの防具除外を変更

### DIFF
--- a/src/app/components/armors/ArmorTable.css
+++ b/src/app/components/armors/ArmorTable.css
@@ -14,3 +14,9 @@
 .ArmorTable .ArmorTable-checkboxCell {
   text-align: center;
 }
+.hit-text {
+  color: salmon;
+}
+.hit-background {
+  background: salmon;
+}

--- a/src/app/components/armors/ArmorTable.tsx
+++ b/src/app/components/armors/ArmorTable.tsx
@@ -8,27 +8,33 @@ interface Props {
   armorGroups: (readonly [string, (string | null)[]])[]
   ignoreArmors: Armors
   toggleIgnoreArmors: (armor: string) => void
+  equip?: string
 }
 
-const ArmorTable: React.FC<Props> = ({ armorGroups, ignoreArmors, toggleIgnoreArmors }) => {
+const ArmorTable: React.FC<Props> = ({ armorGroups, ignoreArmors, toggleIgnoreArmors, equip = '' }) => {
   const { t } = useTranslation()
   const [tEquips] = useTranslation('equips')
   const armorList = [t('頭'), t('胴'), t('腕'), t('腰'), t('足')]
+
+  // hit
+  const getArmorListIndex = (group: (readonly [string, (string | null)[]])) => group[1].indexOf(equip)
+  const hitArmorList = armorGroups.reduce((p, c, i) => -1 !== getArmorListIndex(c) ? getArmorListIndex(c) : p, -1)
+  const hitArmorGroup = armorGroups.reduce((p, c, i) => -1 !== getArmorListIndex(c) ? i : p, -1)
 
   return (
     <Table className="ArmorTable" hoverable>
       <tbody>
         <tr>
           <th></th>
-          {armorList.map((v) =>
-            <th key={v} className="ArmorTable-checkboxCell">{v}</th>
+          {armorList.map((v, i) =>
+            <th key={v} className={`ArmorTable-checkboxCell ${i === hitArmorList ? 'hit-text' : ''}`}>{v}</th>
           )}
         </tr>
-        {armorGroups.map(([group, list]) =>
+        {armorGroups.map(([group, list], i1) =>
           <tr key={group}>
-            <td>{tEquips(group)}</td>
-            {list.map((name, i) =>
-              <td key={i} className="ArmorTable-checkboxCell">
+            <td className={`${i1 === hitArmorGroup ? 'hit-text' : ''}`}>{tEquips(group)}</td>
+            {list.map((name, i2) =>
+              <td key={i2} className={`ArmorTable-checkboxCell ${i1 === hitArmorGroup && i2 === hitArmorList ? 'hit-background' : ''}`}>
                 {!!name &&
                   <input
                     type="checkbox"

--- a/src/app/components/armors/Armors.tsx
+++ b/src/app/components/armors/Armors.tsx
@@ -9,6 +9,7 @@ import { arm, body, getEquip, head, leg, wst } from '~/app/util/generatedUtil'
 import armorGroup from '~/generated/armorGroup.json'
 
 interface Props {
+  init_filter?: string
 }
 
 const armorGroupEntries: [string, (string | null)[]][] = Object.entries(armorGroup)
@@ -26,11 +27,11 @@ const isMatchFilter = (name: string | null, filter: string) =>
 const getDisplayList = (armorGroups: (readonly [string, (string | null)[]])[]) =>
   flat(armorGroups.map(([_, equips]) => equips.filter(Boolean) as string[]))
 
-const Armors: React.FC<Props> = () => {
+const Armors: React.FC<Props> = ({ init_filter = '' }) => {
   const { t } = useTranslation()
   const ignoreArmors = useIgnoreArmors()
   const { toggle, ignoreFromList, clearFromList } = useIgnoreArmorsActions()
-  const [filter, setFilter] = useState('')
+  const [filter, setFilter] = useState(init_filter)
 
   const armorGroups = useMemo(() => (
     armorGroupEntries
@@ -48,6 +49,11 @@ const Armors: React.FC<Props> = () => {
     if (!confirm(t('表示をすべて除外しますか'))) return
 
     ignoreFromList(getDisplayList(armorGroups))
+  }
+
+  if (init_filter && filter === init_filter) {
+    const uniq = [...new Set(Object.keys(armorGroup).map(v => v.replace(/EX|α|β|γ/g, '')).filter(group => init_filter.match(group)))]
+    setFilter(1 === uniq.length ? uniq[0] : init_filter)
   }
 
   return (
@@ -68,7 +74,7 @@ const Armors: React.FC<Props> = () => {
         <Button label={t('表示をすべてチェック')} onClick={checkFromDisplay} />
         <Button label={t('表示をすべて除外')} onClick={uncheckFromDisplay} />
       </div>
-      <ArmorTable armorGroups={armorGroups} ignoreArmors={ignoreArmors} toggleIgnoreArmors={toggle} />
+      <ArmorTable armorGroups={armorGroups} ignoreArmors={ignoreArmors} toggleIgnoreArmors={toggle} equip={init_filter} />
     </div>
   )
 }

--- a/src/app/components/result/ArmorExclude.css
+++ b/src/app/components/result/ArmorExclude.css
@@ -1,0 +1,9 @@
+.ArmorExclude {
+  color: #1A0DAB;
+  cursor: pointer;
+}
+.ArmorExclude.on {
+}
+.ArmorExclude.off {
+  visibility: hidden;
+}

--- a/src/app/components/result/ArmorExclude.tsx
+++ b/src/app/components/result/ArmorExclude.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import Armors from '../armors/Armors'
+import Modal from '../modal/Modal'
+import { arm, body, charm, head, leg, wst } from '~/app/util/generatedUtil'
+
+require('./ArmorExclude.css')
+
+const info: Record<string, typeof arm> = { arm, body, charm, head, leg, wst }
+
+const getEquipInfo = (type: string, name: string) => {
+  const ref = info[type]
+
+  return ref ? ref[name] : null
+}
+
+interface Props {
+  name: string
+  type: string
+}
+
+const ArmorExclude: React.FC<Props> = ({ name, type }) => {
+  const { t } = useTranslation()
+  const [isModalOpen, setModalOpen] = useState(false)
+  const toggleModal = useCallback(() => setModalOpen(state => !state), [])
+  const info = isModalOpen ? getEquipInfo(type, name!) : null
+  return (
+    <>
+      <button className={`ArmorExclude ${name ? 'on' : 'off'}`} onClick={name ? toggleModal : undefined}>E</button>
+      {info &&
+        <Modal className="ArmorExclude-modal" title={t(`防具設定`)} onClose={toggleModal}>
+          <Armors init_filter={name}/>
+        </Modal>
+      }
+    </>
+  )
+}
+
+export default ArmorExclude

--- a/src/app/components/result/ArmorName.tsx
+++ b/src/app/components/result/ArmorName.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import Armors from '../armors/Armors'
 import Table from '../common/Table'
 import Modal from '../modal/Modal'
+import ArmorExclude from './ArmorExclude'
 import SkillTable from './SkillTable'
 import SlotTable from './SlotTable'
 import { useIgnoreArmors, useIgnoreArmorsActions } from '~/app/hooks/ignoreArmors'
@@ -38,6 +40,8 @@ const ArmorName: React.FC<Props> = ({ name, type }) => {
 
   return (
     <>
+      <ArmorExclude name={name} type={type} />
+      {' '}
       <span className={`ArmorName ${name ? 'on' : ''}`} onClick={name ? toggleModal : undefined}>
         {name ? tEquip(name) : t('装備なし')}
       </span>


### PR DESCRIPTION
初めてプルリクエストを送ってみました。
手違いが無いようにしたいと思います。

1.検索結果の各装備にEボタンを表示(Excludeボタン)
  A.`装備なし`の時は、Eボタンのスタイルに`visibility: hidden`を設定します。
    `装備なし`以外の部位と段差が出来ないようにします。
2.Eボタンを押下すると防具設定モーダルが表示され、初期値としてEボタンを押下した装備のグループ名をテキストボックスに入力してフィルタ処理を実施
  A.グループ名からはEX, α, β, γなどを取り除いて、下位、上位、マスターの区別なくリストに表示する。
    シミュレータ使用者は現状作成できない装備や作成が難しい装備を除外したいと思うので、下位、上位、マスターを表示する。
  B.Eボタンが押下された装備が分かるように、グループ名、部位名、チェックボックスのセル背景を変更する。
    チェックボックスの背景を変更しようと思ったが難しそうなので諦めました。
  C.テキストボックスに入力されたグループ名を変更すれば、通常の防具設定と同じように使用できます。
    グループ名を変更してもグループ名、部位名、チェックボックスのセル背景は色が付いたままになります。
3.検索結果の各装備リンクをクリックするとでるモーダルにある除外チェックボックスは残してあります。

以上、宜しくお願いします。